### PR TITLE
Undo redo buttons and message

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -68,8 +68,13 @@ export default {
     });
 
     document.addEventListener('keydown', (e) => {
-      if (e.keyCode === 90 && (e.ctrlKey || e.metaKey) && this.$store.timetravel) {
+      if (!this.$store.timetravel){
+        return;
+      }
+      if (e.keyCode === 90 && (e.ctrlKey || e.metaKey)) {
         e.shiftKey ? this.$store.timetravel.redo() : this.$store.timetravel.undo();
+      } else if (e.keyCode == 89 && (e.ctrlKey || e.metaKey)){
+        this.$store.timetravel.redo();
       }
     });
   },

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -46,7 +46,13 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
     </section>
 
     <section class="tools">
-      <button @click="tool = item" :class="{ active: tool === item }" v-for="item in availableTools">{{ item }}</button>
+      <div class="undo-redo" v-if="timetravelInitialized">
+        <button @click="undo">Undo</button>
+        <button @click="redo">Redo</button>
+      </div>
+      <div>
+        <button @click="tool = item" :class="{ active: tool === item }" v-for="item in availableTools">{{ item }}</button>
+      </div>
     </section>
 
   </nav>
@@ -93,11 +99,18 @@ export default {
 
       if (file) { reader.readAsText(file); }
     },
+    undo() {
+      this.$store.timetravel.undo();
+    },
+    redo() {
+      this.$store.timetravel.redo();
+    },
   },
   computed: {
     ...mapState({
       currentMode: state => state.application.currentSelections.mode,
       mapEnabled: state => state.project.map.enabled,
+      timetravelInitialized: state => state.timetravelInitialized,
     }),
     availableTools() {
       return this.$store.state.application.tools
@@ -189,6 +202,10 @@ export default {
     &.tools {
       background-color: $gray-medium-light;
       justify-content: flex-end;
+
+      > .undo-redo {
+        margin-right: auto;
+      }
     }
 
     > button,

--- a/src/store/timetravel.js
+++ b/src/store/timetravel.js
@@ -55,6 +55,7 @@ export default {
     this.pastTimetravelStates = [];
     this.futureTimetravelStates = [];
 
+    this.store.replaceState({ ...store.state, timetravelInitialized: true });
     /*
     * store.commit and store.replaceState mutate the data store
     * monkey patch them to call the onChange function supplied in app config


### PR DESCRIPTION
@shorowit I believe this covers the [requests you made a few days ago](https://github.com/NREL/openstudio-geometry-editor/issues/101#issuecomment-318116973). The message is just the action name that started the batch. We couldn't think of a way to do automatically generate a more intuitive description: [undo/redo messages](https://trello-attachments.s3.amazonaws.com/58d428743111af1d0a20cf28/5980f484862f0bd56a5773cd/d7d0660e3f817dd2d178eceb8e3ff320/recording.webm)