### PR TITLE
Fix issue 72

### DIFF
--- a/src/components/Grid/methods.js
+++ b/src/components/Grid/methods.js
@@ -393,7 +393,7 @@ export default {
           // if a face on the current story is clicked while the Select tool is active
           // lookup its corresponding model (space/shading) and select it
           this.currentSubSelection = modelHelpers.modelForFace(this.$store.state.models, d.face_id);
-          
+
         } else if (this.currentTool === 'Fill' && (this.currentSpace || this.currentShading)) {
           // if a face on the current story is clicked while the Select tool is active
           // lookup its corresponding model (space/shading) and select it
@@ -603,8 +603,7 @@ export default {
       });
     }
 
-    // TODO Remove this featureUnfinished business once PR#118 is merged.
-    if (!"featureUnfinished (shouldn't have been merged)" && this.points.length === 1 && this.currentTool === 'Rectangle') {
+    if (this.points.length === 1 && this.currentTool === 'Rectangle') {
       snappableVertices = snappableVertices.concat(
         geometryHelpers.syntheticRectangleSnaps(
           snappableVertices,

--- a/src/store/modules/geometry/actions/createFaceFromPoints.js
+++ b/src/store/modules/geometry/actions/createFaceFromPoints.js
@@ -272,7 +272,7 @@ export function errOnEdgeIntersectsEdge(vertices, edges) {
  * validates the face geometry for self intersection
  * returns object with success boolean and face geometry or error message depending on validation results
  */
-export function validateFaceGeometry(points, currentStoryGeometry, snapTolerance) {
+export function validateFaceGeometry(points, currentStoryGeometry) {
   /* validation consists of:
    - try and match each vertex to an existing one that is already in the geometry
    - create edges, and try to re-use existing ones (reversed, if necessary)
@@ -323,8 +323,7 @@ export function validateFaceGeometry(points, currentStoryGeometry, snapTolerance
   // build an array of vertices for the face being created
   let faceVertices = points.map(point => (
       // if a vertex already exists at a given location, reuse it
-      // TODO once PR #118 is ready, remove snap tolerance again
-    geometryHelpers.vertexForCoordinates(point, snapTolerance, currentStoryGeometry) || new factory.Vertex(point.x, point.y)
+    geometryHelpers.vertexForCoordinates(point, currentStoryGeometry) || new factory.Vertex(point.x, point.y)
   ));
 
 

--- a/src/store/modules/geometry/helpers.js
+++ b/src/store/modules/geometry/helpers.js
@@ -219,11 +219,10 @@ const helpers = {
     },
 
     // given a set of coordinates, find the vertex on the geometry set within their tolerance zone
-  vertexForCoordinates(coordinates, snapTolerance, geometry) {
-    // const { x, y } = coordinates;
-    // return geometry.vertices.find(v => v.x === x && v.y === y);
-    // TODO once PR#118 is merged, put this back
-    return geometry.vertices.find(v => this.distanceBetweenPoints(v, coordinates) <= snapTolerance)
+  vertexForCoordinates(coordinates, geometry) {
+    const { x, y } = coordinates;
+    return geometry.vertices.find(v => v.x === x && v.y === y);
+    // return geometry.vertices.find(v => this.distanceBetweenPoints(v, coordinates) < snapTolerance)
   },
 
     // given a face id, returns the populated vertex objects reference by edges on that face
@@ -339,6 +338,7 @@ const helpers = {
       );
     return correctedDiff < 0.05 * Math.PI;
   },
+
 };
 
 export default helpers;

--- a/test/unit/specs/geometry/createFaceFromPoints.spec.js
+++ b/test/unit/specs/geometry/createFaceFromPoints.spec.js
@@ -35,7 +35,7 @@ describe('validateFaceGeometry', () => {
             `);
 
     const
-      res = validateFaceGeometry(points, currentGeometry, 2),
+      res = validateFaceGeometry(points, currentGeometry),
       newVerts = _.reject(res.vertices, v => currentGeometry.vertices.find(c => c.id === v.id));
 
     assert(newVerts.length === 3);
@@ -61,7 +61,7 @@ describe('validateFaceGeometry', () => {
   it('fails when given too few vertices', () => {
     assertProperty(
       genTooFewVerts, (verts) => {
-        const resp = validateFaceGeometry(verts, emptyStoryGeometry, 0);
+        const resp = validateFaceGeometry(verts, emptyStoryGeometry);
         refute(resp && resp.success);
       });
   });
@@ -69,7 +69,7 @@ describe('validateFaceGeometry', () => {
   it('succeeds from empty on a triangle', () => {
     assertProperty(
       genTriangle, (tri) => {
-        const resp = validateFaceGeometry(tri, emptyStoryGeometry, 0);
+        const resp = validateFaceGeometry(tri, emptyStoryGeometry);
         assert(resp && resp.success);
       });
   });
@@ -77,7 +77,7 @@ describe('validateFaceGeometry', () => {
   it('succeeds from empty on a rectangle', () => {
     assertProperty(
       genRectangle, (rect) => {
-        const resp = validateFaceGeometry(rect, emptyStoryGeometry, 0);
+        const resp = validateFaceGeometry(rect, emptyStoryGeometry);
         assert(resp && resp.success);
       });
   });
@@ -85,7 +85,7 @@ describe('validateFaceGeometry', () => {
   it('succeeds from empty on a regular polygon', () => {
     assertProperty(
       genRegularPolygon, (poly) => {
-        const resp = validateFaceGeometry(poly, emptyStoryGeometry, 0);
+        const resp = validateFaceGeometry(poly, emptyStoryGeometry);
         assert(resp && resp.success);
       });
   });
@@ -93,7 +93,7 @@ describe('validateFaceGeometry', () => {
   it('succeeds from empty on an irregular polygon', () => {
     assertProperty(
       genIrregularPolygon, (poly) => {
-        const resp = validateFaceGeometry(poly, emptyStoryGeometry, 0);
+        const resp = validateFaceGeometry(poly, emptyStoryGeometry);
         assert(resp && resp.success);
       });
   });
@@ -110,7 +110,7 @@ describe('validateFaceGeometry', () => {
   it('fails when given a zero-area polygon', () => {
     assertProperty(
       genZeroAreaPolygon, (poly) => {
-        const resp = validateFaceGeometry(poly, emptyStoryGeometry, 0);
+        const resp = validateFaceGeometry(poly, emptyStoryGeometry);
         refute(resp && resp.success);
       });
   });
@@ -139,11 +139,11 @@ describe('validateFaceGeometry', () => {
   it("fails when there's a zero-area portion of the polygon", () => {
     const resp = validateFaceGeometry(
       [{ x: 0, y: 0 }, { x: 5, y: 0 }, { x: 20, y: 0 }, { x: 5, y: 0 },
-        { x: 5, y: 5 }, { x: 0, y: 5 }], emptyStoryGeometry, 0);
+        { x: 5, y: 5 }, { x: 0, y: 5 }], emptyStoryGeometry);
     refute(resp && resp.success);
 
     assertProperty(genPolygonWithSpur, (poly) => {
-      const resp2 = validateFaceGeometry(poly, emptyStoryGeometry, 0);
+      const resp2 = validateFaceGeometry(poly, emptyStoryGeometry);
       refute(resp2 && resp2.success);
     });
   });
@@ -151,7 +151,7 @@ describe('validateFaceGeometry', () => {
   it('fails when the polygon is self-intersecting', () => {
     const resp = validateFaceGeometry(
       [{ x: 0, y: 0 }, { x: 5, y: 0 }, { x: 0, y: 5 }, { x: 5, y: 5 }],
-      emptyStoryGeometry, 0);
+      emptyStoryGeometry);
     refute(resp && resp.success);
   });
 
@@ -159,7 +159,7 @@ describe('validateFaceGeometry', () => {
     // https://trello-attachments.s3.amazonaws.com/58d428743111af1d0a20cf28/598b740a2e569128b4392cb5/f71690195e4801010773652bac9d0a9c/capture.png
     const resp = validateFaceGeometry(
       [{ x: 0, y: 0 }, { x: 5, y: 0 }, { x: 0, y: 3 }, { x: 0, y: 5 }],
-      emptyStoryGeometry, 0);
+      emptyStoryGeometry);
 
     refute(resp && resp.success);
   });
@@ -167,7 +167,7 @@ describe('validateFaceGeometry', () => {
   it('uses existing vertices when they perfectly overlap', () => {
     const resp = validateFaceGeometry(
       [{ x: 0, y: 0 }, { x: 5, y: 0 }, { x: 5, y: 5 }, { x: 0, y: 5 }],
-      neg5by5Rect, 0);
+      neg5by5Rect);
     assert(resp && resp.success);
     assert(_.find(resp.vertices, { x: 0, y: 0 }).id === 'origin');
   });
@@ -175,7 +175,7 @@ describe('validateFaceGeometry', () => {
   it('uses existing edges when they perfectly overlap', () => {
     const resp = validateFaceGeometry(
       [{ x: 0, y: 0 }, { x: -5, y: 0 }, { x: -5, y: 5 }, { x: 0, y: 5 }],
-      neg5by5Rect, 0);
+      neg5by5Rect);
     assert(resp && resp.success);
     assert(_.find(resp.vertices, { x: 0, y: 0 }).id === 'origin');
     assert(_.find(resp.vertices, { x: -5, y: 0 }).id === '(-5, 0)');
@@ -185,7 +185,7 @@ describe('validateFaceGeometry', () => {
   it('uses existing edges when they perfectly overlap (even backwards)', () => {
     const resp = validateFaceGeometry(
       [{ x: 0, y: 5 }, { x: -5, y: 5 }, { x: -5, y: 0 }, { x: 0, y: 0 }],
-      neg5by5Rect, 0);
+      neg5by5Rect);
     assert(resp && resp.success);
     assert(_.find(resp.vertices, { x: 0, y: 0 }).id === 'origin');
     assert(_.find(resp.vertices, { x: -5, y: 0 }).id === '(-5, 0)');


### PR DESCRIPTION
(#118 should be merged first. This PR consists of only one commit)

When drawing rectangles, in addition to snapping to points near the cursor, we want to snap to positions where one of the inferred corners is near an existing vertex. This is most clearly explained with a video: [snap on inferred points](https://trello-attachments.s3.amazonaws.com/58d428743111af1d0a20cf28/5980c9c6be413d73fda6dc9f/f5b6b9daf256e84d2ca9070d45b7afaf/recording.webm)

With this functionality, we no longer need to snap vertices in createFaceFromPoints, which is the reason @ljbrackney's [rectangles kept turning into trapezoids](https://github.com/NREL/openstudio-geometry-editor/issues/72#issuecomment-310134046). Here's a video where I've disabled snapping by holding down shift, and I'm able to get very close to the point without snapping to it and creating an diagonal: [no unintentional diagonals](https://trello-attachments.s3.amazonaws.com/58d428743111af1d0a20cf28/5980cbe770c6655232a05089/120d006fa35029ffc99aa9c7469c7ae0/recording.webm)

