### PR TITLE
Fix 132

### DIFF
--- a/src/components/Grid/methods.js
+++ b/src/components/Grid/methods.js
@@ -897,6 +897,8 @@ export default {
 
     this.axis.x = svg.append('g')
     .attr('class', 'axis axis--x')
+    .attr('transform', 'translate(-0.5, 0)') // this corrects some mistake elsewhere in the code that I can't track down.
+    // or potentially related to this, combined with our setting the viewBox: https://groups.google.com/forum/#!topic/d3-js/-Sw0Wdnkeko
     .attr('stroke-width', strokeWidth)
     .style('font-size',fontSize)
     .style('display', this.gridVisible ? 'inline' : 'none')
@@ -904,6 +906,7 @@ export default {
 
     this.axis.y = svg.append('g')
     .attr('class', 'axis axis--y')
+    .attr('transform', 'translate(0, -0.5)') // this corrects some mistake elsewhere in the code that I can't track down.
     .attr('stroke-width', strokeWidth)
     .style('font-size',fontSize)
     .style('display', this.gridVisible ? 'inline' : 'none')

--- a/src/scss/partials/d3.scss
+++ b/src/scss/partials/d3.scss
@@ -66,6 +66,9 @@
             fill-opacity: 0.3;
             z-index: -1;
         }
+        &.domain {
+          stroke: #fff;
+        }
 		&.previousStory {
 			stroke-dasharray: 10;
 			stroke: $black;


### PR DESCRIPTION
This issue was due to setting the viewbox, combined with a 0.5 offset that is automatically applied to d3 axes: https://groups.google.com/forum/#!topic/d3-js/-Sw0Wdnkeko

I believe that the crazy font sizes may also be related to the fact that the viewbox is set -- it causes scaling on everything inside the svg. I'm going to look into removing it entirely, which would supercede this fix. In the meantime, this represents about 6-8 hours of struggle and pulling out hair on my part.

fixes #132 