### PR TITLE
Remove view box

### DIFF
--- a/src/components/Canvas/Images.vue
+++ b/src/components/Canvas/Images.vue
@@ -91,10 +91,6 @@ export default {
       this.layer = new Konva.Layer();
       this.stage.add(this.layer);
 
-      this.layer.add(new Konva.Circle({ x: this.rwuXtoPx(0), y: this.rwuYtoPx(0), radius: 5, name: 'origin', fill: '#00f' }));
-      this.layer.add(new Konva.Circle({ x: this.rwuXtoPx(100), y: this.rwuYtoPx(0), radius: 5, name: '(100, 0)', fill: '#00f'  }));
-      this.layer.add(new Konva.Circle({ x: this.rwuXtoPx(-100), y: this.rwuYtoPx(0), radius: 5, name: '(-100, 0)', fill: '#00f'  }));
-      this.layer.add(new Konva.Circle({ x: this.rwuXtoPx(0), y: this.rwuYtoPx(100), radius: 5, name: '(0, 100)', fill: '#00f'  }));
       // render each image in the store
       this.images.forEach(this.renderImage);
 

--- a/src/components/Canvas/Images.vue
+++ b/src/components/Canvas/Images.vue
@@ -26,6 +26,7 @@ export default {
       layer: null,
       // cache images on the component so that we can check which property was altered in the images watcher
       imageCache: [],
+      originalStageResolution: null,
     };
   },
   mounted() {
@@ -51,6 +52,9 @@ export default {
         width: document.getElementById('canvas').clientWidth,
         height: document.getElementById('canvas').clientHeight,
       });
+      // original rwu/px resolution when scales were set
+      this.originalStageResolution =  (this.scaleX.range()[1] - this.scaleX.range()[0]) / (this.scaleX.domain()[1] - this.scaleX.domain()[0]);
+
       this.layer = new Konva.Layer();
       this.stage.add(this.layer);
 
@@ -367,12 +371,10 @@ export default {
     * Set the scale and position of the canvas based on the current viewbox
     */
     scaleAndPlaceStage() {
-      // original rwu/px resolution when scales were set
-      const originalResolution = (this.scaleX.range()[1] - this.scaleX.range()[0]) / (this.scaleX.domain()[1] - this.scaleX.domain()[0]);
       // current rwu/px resolution based on current viewbox (after panning and zooming)
       const currentResolution = (this.view.max_x - this.view.min_x) / this.$refs.images.clientWidth;
       // scaling factor to render canvas images at current resolution
-      const scale = originalResolution / currentResolution;
+      const scale = this.originalStageResolution / currentResolution;
 
       this.stage
         // scale will not be 1 if the user has zoomed in or out

--- a/src/components/Canvas/Images.vue
+++ b/src/components/Canvas/Images.vue
@@ -50,7 +50,6 @@ export default {
     };
   },
   mounted() {
-    window.canvas = this;
     this.debouncedRenderImages = _.debounce(this.renderImages, 10);
 
     ResizeEvents.$on('resize', this.renderImages);
@@ -401,9 +400,7 @@ export default {
     * Set the scale and position of the canvas based on the current viewbox
     */
     scaleAndPlaceStage() {
-      // console.log('at last render', this.transformAtLastRender);
       const transform = transformDiff(this.transformAtLastRender, this.transform);
-      console.log('resultant t', transform);
       // current rwu/px resolution based on current viewbox (after panning and zooming)
       this.stage
         // scale will not be 1 if the user has zoomed in or out
@@ -490,14 +487,12 @@ export default {
     },
     // if the view boundaries change
     pixelWidth() {
-      console.log('new canvas width,', this.pixelWidth);
       this.debouncedRenderImages();
     },
     pixelHeight() {
       this.debouncedRenderImages();
     },
     transform() {
-      console.log(JSON.stringify(this.transform));
       this.scaleAndPlaceStage();
     },
   },

--- a/src/components/Grid/Grid.vue
+++ b/src/components/Grid/Grid.vue
@@ -42,7 +42,6 @@ export default {
         k: 1, // relative (to window after resize) zoom
       },
       handleMouseMove: null, // placeholder --> overwritten in mounted()
-      forceGridHide: false,
     };
   },
   mounted() {
@@ -197,10 +196,10 @@ export default {
     },
   },
   watch: {
+    // showTicks() { this.showOrHideAxes(); },
     // TODO: method for when new view dimensions are imported or the px dimensions change
-    gridVisible() { this.updateGrid(); },
+    gridVisible() { this.showOrHideAxes(); },
     spacing() { this.updateGrid(); },
-    forceGridHide() { this.updateGrid(); },
 
     currentMode() { this.drawPolygons(); },
     polygons() { this.drawPolygons(); },
@@ -224,9 +223,6 @@ export default {
       this.drawPoints();
     },
     transform(newTransform, lastTransform) {
-      // hide grid if zoomed out enough
-      this.forceGridHide = (newTransform.k < 0.1);
-
       // hide polygon names if zoomed out enough
       if (newTransform.k < 0.5) {
         d3.select('#svg-grid').selectAll('.polygon-text').style('display', 'none');

--- a/src/components/Grid/Grid.vue
+++ b/src/components/Grid/Grid.vue
@@ -36,39 +36,33 @@ export default {
         x: null,
         y: null,
       },
-      transform: {
-        x: 0,
-        y: 0,
-        k: 1, // relative (to window after resize) zoom
-      },
       handleMouseMove: null, // placeholder --> overwritten in mounted()
     };
   },
   mounted() {
+    window.grid = this;
     // throttle/debounce event handlers
     this.handleMouseMove = throttle(this.highlightSnapTarget, 100);
     this.renderGrid = debounce(this.renderGrid, 5);
 
     // add event listeners
-    this.$refs.grid.addEventListener('reloadGrid', this.renderGrid);
-    this.$refs.grid.addEventListener('reloadGridScales', this.reloadGridAndScales);
+    this.$refs.grid.addEventListener('reloadGrid', this.reloadGridAndScales);
 
     window.addEventListener('keyup', this.escapeAction);
-    window.addEventListener('resize', this.renderGrid);
+    window.addEventListener('resize', this.reloadGridAndScales);
 
-    ResizeEvents.$on('resize', this.renderGrid);
+    ResizeEvents.$on('resize', this.reloadGridAndScales);
 
     // render grid first time
     this.renderGrid();
   },
   beforeDestroy() {
-    this.$refs.grid.removeEventListener('reloadGrid', this.renderGrid);
-    this.$refs.grid.removeEventListener('reloadGridScales', this.reloadGridAndScales);
+    this.$refs.grid.removeEventListener('reloadGrid', this.reloadGridAndScales);
 
     window.removeEventListener('keyup', this.escapeAction);
-    window.removeEventListener('resize', this.renderGrid);
+    window.removeEventListener('resize', this.reloadGridAndScales);
 
-    ResizeEvents.$off('resize', this.renderGrid);
+    ResizeEvents.$off('resize', this.reloadGridAndScales);
   },
   computed: {
 
@@ -110,6 +104,10 @@ export default {
     max_y: {
       get() { return this.$store.state.project.view.max_y; },
       set(val) { this.$store.dispatch('project/setViewMaxY', { max_y: val }); },
+    },
+    transform: {
+      get() { return this.$store.state.project.transform; },
+      set(t) { this.$store.dispatch('project/setTransform', t); },
     },
     // previous story
     previousStory() {
@@ -234,6 +232,7 @@ export default {
       if (this.points.length && (newTransform.k !== lastTransform.k || Math.abs(lastTransform.y - newTransform.y) > 3 || Math.abs(lastTransform.x - newTransform.x) > 3)) {
         this.points = [];
       }
+      console.log(JSON.stringify(newTransform));
     },
   },
   methods,

--- a/src/components/Grid/Grid.vue
+++ b/src/components/Grid/Grid.vue
@@ -227,10 +227,11 @@ export default {
       this.forceGridHide = (newTransform.k < 0.1);
 
       // hide polygon names if zoomed out enough
-      if (newTransform.k < 0.5) {
+      console.log('newTransform.kAbs', newTransform.kAbs);
+      if (newTransform.kAbs < 0.5) {
         d3.select('#svg-grid').selectAll('.polygon-text').style('display', 'none');
       } else {
-        d3.select('#svg-grid').selectAll('.polgyon-text').style('display', 'initial');
+        d3.select('#svg-grid').selectAll('.polygon-text').style('display', 'initial');
       }
 
       // cancel current drawing action if actual zoom and not just accidental drag

--- a/src/components/Grid/Grid.vue
+++ b/src/components/Grid/Grid.vue
@@ -175,6 +175,7 @@ export default {
             return geometryHelpers.vertexForId(nextVertexId, this.currentStoryGeometry);
           }),
         };
+        polygon.labelPosition = this.polygonLabelPosition(polygon.points);
 
         // if the model is a space, set the polygon's color based on the current mode
         if (model.type === 'space') {
@@ -223,10 +224,10 @@ export default {
     },
     transform(newTransform, lastTransform) {
       // hide grid if zoomed out enough
-      this.forceGridHide = (newTransform.kAbs < 0.1);
+      this.forceGridHide = (newTransform.k < 0.1);
 
       // hide polygon names if zoomed out enough
-      if (newTransform.kAbs < 0.5) {
+      if (newTransform.k < 0.5) {
         d3.select('#svg-grid').selectAll('.polygon-text').style('display', 'none');
       } else {
         d3.select('#svg-grid').selectAll('.polgyon-text').style('display', 'initial');

--- a/src/components/Grid/Grid.vue
+++ b/src/components/Grid/Grid.vue
@@ -40,7 +40,6 @@ export default {
         x: 0,
         y: 0,
         k: 1, // relative (to window after resize) zoom
-        kAbs: 1, // absolute zoom
       },
       handleMouseMove: null, // placeholder --> overwritten in mounted()
       forceGridHide: false,
@@ -53,6 +52,7 @@ export default {
 
     // add event listeners
     this.$refs.grid.addEventListener('reloadGrid', this.renderGrid);
+    this.$refs.grid.addEventListener('reloadGridScales', this.reloadGridAndScales);
 
     window.addEventListener('keyup', this.escapeAction);
     window.addEventListener('resize', this.renderGrid);
@@ -64,6 +64,7 @@ export default {
   },
   beforeDestroy() {
     this.$refs.grid.removeEventListener('reloadGrid', this.renderGrid);
+    this.$refs.grid.removeEventListener('reloadGridScales', this.reloadGridAndScales);
 
     window.removeEventListener('keyup', this.escapeAction);
     window.removeEventListener('resize', this.renderGrid);
@@ -227,15 +228,14 @@ export default {
       this.forceGridHide = (newTransform.k < 0.1);
 
       // hide polygon names if zoomed out enough
-      console.log('newTransform.kAbs', newTransform.kAbs);
-      if (newTransform.kAbs < 0.5) {
+      if (newTransform.k < 0.5) {
         d3.select('#svg-grid').selectAll('.polygon-text').style('display', 'none');
       } else {
         d3.select('#svg-grid').selectAll('.polygon-text').style('display', 'initial');
       }
 
       // cancel current drawing action if actual zoom and not just accidental drag
-      if (this.points.length && (newTransform.kAbs !== lastTransform.kAbs || Math.abs(lastTransform.y - newTransform.y) > 3 || Math.abs(lastTransform.x - newTransform.x) > 3)) {
+      if (this.points.length && (newTransform.k !== lastTransform.k || Math.abs(lastTransform.y - newTransform.y) > 3 || Math.abs(lastTransform.x - newTransform.x) > 3)) {
         this.points = [];
       }
     },

--- a/src/components/Grid/Grid.vue
+++ b/src/components/Grid/Grid.vue
@@ -40,7 +40,6 @@ export default {
     };
   },
   mounted() {
-    window.grid = this;
     // throttle/debounce event handlers
     this.handleMouseMove = throttle(this.highlightSnapTarget, 100);
     this.renderGrid = debounce(this.renderGrid, 5);
@@ -232,7 +231,6 @@ export default {
       if (this.points.length && (newTransform.k !== lastTransform.k || Math.abs(lastTransform.y - newTransform.y) > 3 || Math.abs(lastTransform.x - newTransform.x) > 3)) {
         this.points = [];
       }
-      console.log(JSON.stringify(newTransform));
     },
   },
   methods,

--- a/src/components/Grid/methods.js
+++ b/src/components/Grid/methods.js
@@ -463,7 +463,7 @@ export default {
           .attr('y', y)
           .text(poly.name)
           .attr('text-anchor', 'middle')
-          .style('font-size', '18px')
+          .style('font-size', '14px')
           .style('font-weight', 'bold')
           .attr('font-family', 'sans-serif')
           .attr('fill', 'red')
@@ -871,7 +871,7 @@ export default {
       zoomYScale = this.yScale.copy(),
       // keep font size and stroke width visually consistent
       strokeWidth = 1,
-      fontSize = '18px';
+      fontSize = '14px';
 
     svg.selectAll('*').remove();
     svg.attr('height', height)

--- a/src/components/Grid/methods.js
+++ b/src/components/Grid/methods.js
@@ -86,8 +86,8 @@ export default {
       .append('ellipse')
       .attr('cx', ellipsePoint.x, 'x')
       .attr('cy', ellipsePoint.y, 'y')
-      .attr('rx', this.scaleX(5))
-      .attr('ry', this.scaleY(5))
+      .attr('rx', 5)
+      .attr('ry', 5)
       .classed('highlight', true)
       .attr('vector-effect', 'non-scaling-stroke');
     } else {
@@ -95,8 +95,8 @@ export default {
       .append('ellipse')
       .attr('cx', ellipsePoint.x)
       .attr('cy', ellipsePoint.y)
-      .attr('rx', this.scaleX(2))
-      .attr('ry', this.scaleY(2))
+      .attr('rx', 2)
+      .attr('ry', 2)
       .classed('gridpoint', true)
       .attr('vector-effect', 'non-scaling-stroke');
     }
@@ -349,14 +349,14 @@ export default {
     .enter().append('ellipse')
     .attr('cx', d => d.x)
     .attr('cy', d => d.y)
-    .attr('rx', this.scaleX(2))
-    .attr('ry', this.scaleY(2))
+    .attr('rx', 2)
+    .attr('ry', 2)
     .attr('vector-effect', 'non-scaling-stroke');
 
     // apply custom CSS for origin of polygons
     d3.select('#grid svg').select('ellipse')
-    .attr('rx', this.scaleX(7))
-    .attr('ry', this.scaleY(7))
+    .attr('rx', 7)
+    .attr('ry', 7)
     .classed('origin', true)
     .attr('vector-effect', 'non-scaling-stroke')
     .attr('fill', 'none');
@@ -978,17 +978,6 @@ export default {
   // ****************** SCALING FUNCTIONS ****************** //
 
   /*
-  * take a pixel value (from a mouse event), find the corresponding coordinates in the svg grid
-  */
-  pxToGrid (px, axis) {
-    if (axis === 'x') {
-      return this.scaleX && this.scaleX(px);
-    } else if (axis === 'y') {
-      return this.scaleY && this.scaleY(px);
-    }
-  },
-
-  /*
   * take a rwu value (from the datastore), find the corresponding coordinates in the svg grid
   */
   rwuToGrid (rwu, axis) {
@@ -1051,7 +1040,7 @@ export default {
     let min = Math.abs(this.min_y),
     max = Math.abs(this.max_y),
     numDigits = (min < max ? max : min).toFixed(0).length,
-    yPadding = this.scaleX(paddingPerDigit*numDigits);
+    yPadding = paddingPerDigit * numDigits;
 
     this.axis.y.call(this.axis_generator.y.tickPadding(yPadding));
   }

--- a/src/components/Grid/methods.js
+++ b/src/components/Grid/methods.js
@@ -873,7 +873,7 @@ export default {
     }
 
     this.calcGrid();
-    this.centerGrid();
+    //this.centerGrid();
     this.drawPolygons();
   },
   recalcScales() {
@@ -934,6 +934,7 @@ export default {
     .style('display', this.gridVisible ? 'inline' : 'none')
     .call(this.axis_generator.y);
 
+    console.log('should have grid now');
     // configure zoom behavior in rwu
     this.zoomBehavior = d3.zoom()
     .scaleExtent([0.02,Infinity])
@@ -982,10 +983,6 @@ export default {
     const
       width = this.$refs.grid.clientWidth,
       height = this.$refs.grid.clientHeight;
-
-    // const x = this.min_x + (this.max_x - this.min_x)/2,
-    // // y = this.min_y + (this.max_y - this.min_y)/2;
-    // y = this.min_y - (this.max_y - this.min_y)/2; // inverted y axis
 
     d3.select('#grid svg').call(this.zoomBehavior.transform, d3.zoomIdentity.translate(width / 2, height / 2));
   },

--- a/src/components/Grid/methods.js
+++ b/src/components/Grid/methods.js
@@ -883,7 +883,6 @@ export default {
   reloadGridAndScales() {
     this.zoomXScale = null;
     this.zoomYScale = null;
-    d3.select('#grid svg').selectAll('*').remove();
     this.resolveBounds();
     this.renderGrid();
   },
@@ -969,6 +968,9 @@ export default {
 
        // redraw the saved geometry
        this.drawPolygons();
+     })
+     .on('end', () => {
+       ResizeEvents.$emit('zoomStabilized');
      });
 
     svg.call(this.zoomBehavior);

--- a/src/components/Grid/methods.js
+++ b/src/components/Grid/methods.js
@@ -926,7 +926,7 @@ export default {
 
     // configure zoom behavior in rwu
     this.zoomBehavior = d3.zoom()
-    .scaleExtent([0.02, Infinity])
+    .scaleExtent([0.02, 200])
      .on('zoom', () => {
        const transform = d3.event.transform;
        // update stored transform for grid hiding, etc.

--- a/src/components/Grid/methods.js
+++ b/src/components/Grid/methods.js
@@ -222,8 +222,8 @@ export default {
 
       // render unfinished area #
       svg.append('text')
-      .attr('x', x)
-      .attr('y', y)
+      .attr('x', this.rwuToGrid(x, 'x'))
+      .attr('y', this.rwuToGrid(y, 'y'))
       .text(areaText)
       .classed('guideline guideline-text guideLine',true)
       .attr("text-anchor", "middle")
@@ -948,11 +948,13 @@ export default {
       return;
     }
     // configure zoom behavior in rwu
+    let kAbs = 1;
     this.zoomBehavior = d3.zoom()
     .scaleExtent([0.02,Infinity])
      .on('zoom', () => {
-      const transform = d3.event.transform,
-      kAbs = transform.k/this.scaleX(1); // absolute zoom, regardless of resizing, etc.
+       const transform = d3.event.transform;
+       kAbs *= transform.k; // absolute zoom, regardless of resizing, etc.
+       console.log('kAbs', kAbs);
 
       // update stored transform for grid hiding, etc.
       this.transform = { ...transform, kAbs };

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -125,8 +125,6 @@ export default {
       max_y: state => state.project.view.max_y,
       min_x: state => state.project.view.min_x,
       min_y: state => state.project.view.min_y,
-      scaleX: state => state.application.scale.x,
-      scaleY: state => state.application.scale.y,
     }),
 
     ...mapGetters({
@@ -272,7 +270,6 @@ export default {
               x: that.min_x + (rwuWidth / 2),
               y: that.max_y - (rwuHeight / 2),
             });
-            console.log('initial img width', rwuWidth, 'img height', rwuHeight);
           };
           image.src = reader.result;
         }, false);

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -272,6 +272,7 @@ export default {
               x: that.min_x + (rwuWidth / 2),
               y: that.max_y - (rwuHeight / 2),
             });
+            console.log('initial img width', rwuWidth, 'img height', rwuHeight);
           };
           image.src = reader.result;
         }, false);

--- a/src/store/modules/models/actions.js
+++ b/src/store/modules/models/actions.js
@@ -178,22 +178,17 @@ export default {
   createImageForStory(context, payload) {
     const story = context.state.stories.find(s => s.id === payload.story_id);
     const name = helpers.generateName(context.state, 'images', story);
-    const img = new Image();
+    const image = new factory.Image(name, payload.src);
 
-    img.onload = () => {
-      const image = new factory.Image(name, payload.src);
+    image.height = payload.height;
+    image.width = payload.width;
+    image.x = payload.x;
+    image.y = payload.y;
 
-      image.height = payload.height;
-      image.width = payload.width;
-      image.x = payload.x;
-      image.y = payload.y;
-
-      context.commit('createImageForStory', {
-        story_id: story.id,
-        image,
-      });
-    };
-    img.src = payload.src;
+    context.commit('createImageForStory', {
+      story_id: story.id,
+      image,
+    });
   },
 
     createObjectWithType (context, payload) {

--- a/src/store/modules/project/actions.js
+++ b/src/store/modules/project/actions.js
@@ -112,4 +112,8 @@ export default {
     setShowImportExport(context, payload) {
       context.commit('setShowImportExport', payload);
     },
+
+    setTransform(context, payload) {
+      context.commit('setTransform', payload);
+    },
 }

--- a/src/store/modules/project/index.js
+++ b/src/store/modules/project/index.js
@@ -13,14 +13,14 @@ export default {
     },
     grid: {
       visible: true,
-      spacing: 50
+      spacing: 50,
     },
     view: {
       // grid boundaties in rwu
       min_x: 0,
       min_y: 0,
       max_x: 1000,
-      max_y: 1000
+      max_y: 1000,
     },
     map: {
       initialized: false,

--- a/src/store/modules/project/index.js
+++ b/src/store/modules/project/index.js
@@ -13,14 +13,14 @@ export default {
     },
     grid: {
       visible: true,
-      spacing: 50,
+      spacing: 5,
     },
     view: {
       // grid boundaties in rwu
-      min_x: 0,
-      min_y: 0,
-      max_x: 1000,
-      max_y: 1000,
+      min_x: -250,
+      min_y: -150,
+      max_x: 250,
+      max_y: 150,
     },
     map: {
       initialized: false,

--- a/src/store/modules/project/index.js
+++ b/src/store/modules/project/index.js
@@ -36,6 +36,9 @@ export default {
       visible: true
     },
     showImportExport: true,
+    transform: {
+      k: 1, x: 0, y: 0,
+    },
   },
   actions: actions,
   mutations: mutations,

--- a/src/store/modules/project/mutations.js
+++ b/src/store/modules/project/mutations.js
@@ -94,7 +94,10 @@ export default {
             state.previous_story.visible = payload.visible;
         }
     },
-    setShowImportExport(state, payload) {
-      state.showImportExport = payload;
-    }
+  setShowImportExport(state, payload) {
+    state.showImportExport = payload;
+  },
+  setTransform(state, payload) {
+    state.transform = payload;
+  },
 }

--- a/src/store/timetravel.js
+++ b/src/store/timetravel.js
@@ -14,6 +14,7 @@ const filteredActions = [
   'project/setViewMinY',
   'project/setViewMaxX',
   'project/setViewMaxY',
+  'project/setTransform',
   'application/clearSubSelections',
   'application/setCurrentStoryId',
   'application/setCurrentStory',
@@ -117,7 +118,10 @@ export default {
     const store = this.store;
     _.defer(() => {
       // after save checkpoint and dust has settled
-      while (_.isEqual(serializeState(store.state), prevStates[prevStates.length - 1].state)) {
+      while (
+        prevStates.length > 0 &&
+        _.isEqual(serializeState(store.state), prevStates[prevStates.length - 1].state)
+      ) {
         console.log('current state matches previous, so rolling back', prevStates[prevStates.length - 1].triggeringAction);
         prevStates.pop();
       }

--- a/src/store/utilities/importFloorplan.js
+++ b/src/store/utilities/importFloorplan.js
@@ -79,5 +79,5 @@ export default function importFloorplan(context, payload) {
     geometry,
   });
 
-  document.getElementById('svg-grid').dispatchEvent(new Event('reloadGridScales'));
+  document.getElementById('svg-grid').dispatchEvent(new Event('reloadGrid'));
 }

--- a/src/store/utilities/importFloorplan.js
+++ b/src/store/utilities/importFloorplan.js
@@ -79,5 +79,5 @@ export default function importFloorplan(context, payload) {
     geometry,
   });
 
-  document.getElementById('svg-grid').dispatchEvent(new Event('reloadGrid'));
+  document.getElementById('svg-grid').dispatchEvent(new Event('reloadGridScales'));
 }


### PR DESCRIPTION
fixes #100, #174, and #132.

This is the longer-term fix whose arrival was foretold in #184 🔮  👻 .

The main point of this PR is removing this line:
```
this.$refs.grid.setAttribute('viewBox', `0 0 ${this.max_x - this.min_x} ${this.max_y - this.min_y}`);
```
Almost everything else was removing the workarounds that were added to accommodate that line, or adding things to correct for the fact that we're now working on the scale of pixels instead of real-world-units.

That line said "scale everything inside the svg so that when I say "1" I mean "1 meter" or "1 foot", instead of "1 pixel" as would be the default. That meant:

- font sizes now needed to be scaled. "12" wasn't "12pt", it was "12m", so they were scaled down to avoid taking up the whole screen. This didn't always work, as in #100.
- When working in a small region, say, `max_x - min_x` less than 20 or so, there was a noticeable offset between where the grid was drawn, and where click events registered. This is because d3 applies a 0.5 offset when drawing axes (https://groups.google.com/forum/#!topic/d3-js/-Sw0Wdnkeko) in order to fix a rendering bug in safari. 0.5 was intended to mean '0.5pixels', but was being interpreted as '0.5 ft'.

Also in this PR, I changed the grid and polygon drawing code to update existing DOM nodes if possible, rather than destroying and creating new ones. Not sure if that actually improves things, since vue was going to do a virtual dom diff anyway. ¯\\\_(ツ)_/¯ 