### PR TITLE
Click on poly test

### DIFF
--- a/src/scss/partials/d3.scss
+++ b/src/scss/partials/d3.scss
@@ -63,7 +63,6 @@
     polygon, rect, path {
         fill-opacity: .9;
         z-index: 3;
-        pointer-events: all;
         stroke: $gray-light;
         &.domain {
           stroke: #fff;

--- a/src/scss/partials/d3.scss
+++ b/src/scss/partials/d3.scss
@@ -63,6 +63,7 @@
     polygon, rect, path {
         fill-opacity: .9;
         z-index: 3;
+        pointer-events: all;
         stroke: $gray-light;
         &.domain {
           stroke: #fff;

--- a/test/e2e/specs/test.js
+++ b/test/e2e/specs/test.js
@@ -57,6 +57,34 @@ module.exports = {
       .checkForErrors()
       .end();
   },
+  'in-progress spaces should not capture clicks': (browser) => {
+    withScales(failOnError(browser))
+      .waitForElementVisible('.modal .new-floorplan', 5000)
+      .setFlagOnError()
+      .click('.modal .new-floorplan svg')
+      .getScales()
+      .perform((client, done) => {
+        const x0 = -50, y0 = 50;
+        console.log(`moving to ${client.xScale(x0)}, ${client.yScale(y0)}`);
+        client
+          .waitForElementVisible('#grid svg', 200)
+          .pause(10)
+          .moveToElement('#grid svg', client.xScale(x0), client.yScale(y0))
+          .pause(10)
+          .mouseButtonClick()
+          .pause(10)
+          .moveToElement('#grid svg', client.xScale(x0 + 50), client.yScale(y0 - 50))
+          .pause(10)
+          .moveToElement('#grid svg', client.xScale(x0 + 48), client.yScale(y0 - 48))
+          .mouseButtonClick();
+
+        done();
+      })
+      .keys([browser.Keys.ESCAPE])
+      .assert.elementCount('.poly', 1)
+      .checkForErrors()
+      .end();
+  },
   'switch to shading and back, preserve selected space': (browser) => {
     const devServer = browser.globals.devServerURL;
 


### PR DESCRIPTION
Add test for "drawing operations seem flaky" issue. We've caused a regression here in the past, so it's good to have a test.

The issue was that we sometimes need polygons to catch pointer events (fill operation, component placement), but the polygon can get in the way of drawing ops. The click event hits the polygon instead of the grid.