### PR TITLE
Hex color format

### DIFF
--- a/schema/geometry_schema.json
+++ b/schema/geometry_schema.json
@@ -521,7 +521,7 @@
 				},
 				"color": {
 					"type": [
-						"string",
+						"HexColor",
 						"null"
 					]
 				},
@@ -810,7 +810,7 @@
 				},
 				"color": {
 					"type": [
-						"string",
+						"HexColor",
 						"null"
 					]
 				}
@@ -842,7 +842,7 @@
 				},
 				"color": {
 					"type": [
-						"string",
+						"HexColor",
 						"null"
 					]
 				}
@@ -874,7 +874,7 @@
 				},
 				"color": {
 					"type": [
-						"string",
+						"HexColor",
 						"null"
 					]
 				}
@@ -1163,7 +1163,7 @@
 				},
 				"color": {
 					"type": [
-						"string",
+						"HexColor",
 						"null"
 					]
 				}
@@ -1176,6 +1176,10 @@
 				"shed_direction",
 				"color"
 			]
+		},
+		"HexColor": {
+			"type": "string",
+			"pattern": "^#[a-fA-F0-9]{6}$"
 		}
 	}
 }

--- a/schema/geometry_schema.json
+++ b/schema/geometry_schema.json
@@ -520,10 +520,7 @@
 					"default": 1
 				},
 				"color": {
-					"type": [
-						"HexColor",
-						"null"
-					]
+					"$ref": "#/definitions/HexColor"
 				},
 				"geometry": {
 					"$ref": "#/definitions/Geometry"
@@ -809,10 +806,7 @@
 					]
 				},
 				"color": {
-					"type": [
-						"HexColor",
-						"null"
-					]
+					"$ref": "#/definitions/HexColor"
 				}
 			},
 			"required": [
@@ -841,10 +835,7 @@
 					]
 				},
 				"color": {
-					"type": [
-						"HexColor",
-						"null"
-					]
+					"$ref": "#/definitions/HexColor"
 				}
 			},
 			"required": [
@@ -873,10 +864,7 @@
 					]
 				},
 				"color": {
-					"type": [
-						"HexColor",
-						"null"
-					]
+					"$ref": "#/definitions/HexColor"
 				}
 			},
 			"required": [
@@ -1162,10 +1150,7 @@
 					"ip_units": "deg"
 				},
 				"color": {
-					"type": [
-						"HexColor",
-						"null"
-					]
+					"$ref": "#/definitions/HexColor"
 				}
 			},
 			"required": [
@@ -1178,7 +1163,7 @@
 			]
 		},
 		"HexColor": {
-			"type": "string",
+			"type": ["null", "string"],
 			"pattern": "^#[a-fA-F0-9]{6}$"
 		}
 	}

--- a/src/store/utilities/export.js
+++ b/src/store/utilities/export.js
@@ -2,6 +2,14 @@ import _ from 'lodash';
 import version from '../../version';
 import { repeatingWindowCenters } from '../../store/modules/geometry/helpers';
 
+function formatHex(val) {
+  if (!val) { return null; }
+  if (val.length === 4) {
+    return `#${val[1]}${val[1]}${val[2]}${val[2]}${val[3]}${val[3]}`;
+  }
+  return val;
+}
+
 function formatObject(obj) {
   if (_.isArray(obj)) {
     return obj.map(formatObject);
@@ -9,6 +17,9 @@ function formatObject(obj) {
     return _.mapValues(obj, (val, key) => {
       if ((key === 'id' || key.indexOf('_id') >= 0) && _.isNumber(val)) {
         return String(val);
+      }
+      if (key === 'color') {
+        return formatHex(val);
       }
       return formatObject(val);
     });


### PR DESCRIPTION
addresses #285 

@macumber I added a definition to the schema to make sure we're testing for this -- hope that's alright.
We're testing for backwards compatibility with old exports in `test/e2e/specs/importFloorplans.js`, where we import several old floorplan files and assert that the satisfy the schema upon export.