### PR TITLE
defaults have specific units.

### DIFF
--- a/schema/geometry_schema.json
+++ b/schema/geometry_schema.json
@@ -101,10 +101,10 @@
 								"null"
 							],
 							"enum": [
-								"ft",
-								"m"
+								"ip",
+								"si"
 							],
-							"default": "ft"
+							"default": "ip"
 						},
 						"language": {
 							"type": [

--- a/src/api.js
+++ b/src/api.js
@@ -37,7 +37,7 @@ window.api = {
     }
     window.api.config = Object.assign({
       showImportExport: true,
-      units: 'm',
+      units: 'si',
       unitsEditable: true,
       showMapDialogOnStart: false,
       online: true,

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -291,7 +291,7 @@ export default {
       mapEnabled: state => state.project.map.enabled,
       timetravelInitialized: state => state.timetravelInitialized,
       showImportExport: state => state.project.show_import_export,
-      allowSettingUnits: state => state.project.config.unitsEditable && state.geometry.length === 1 && state.geometry[0].vertices.length === 0,
+      allowSettingUnits: state => false, //state.project.config.unitsEditable && state.geometry.length === 1 && state.geometry[0].vertices.length === 0,
     }),
     currentSubselectionType: {
       get() { return this.$store.state.application.currentSelections.subselectionType; },

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -358,8 +358,8 @@ export default {
       },
     },
     rwUnits: {
-      get() { return this.$store.state.project.config.units; },
-      set(units) { this.$store.dispatch('project/setUnits', { units }); },
+      get() { return this.$store.state.project.config.units === 'ip' ? 'ft' : 'm'; },
+      set(units) { this.$store.dispatch('project/setUnits', { units: units === 'ft' ? 'ip' : 'si' }); },
     },
     snapMode: {
       get() { return this.$store.state.application.currentSelections.snapMode; },

--- a/src/store/modules/geometry/actions/actions.js
+++ b/src/store/modules/geometry/actions/actions.js
@@ -23,6 +23,9 @@ export default {
       geometry_id: geometry.id,
     }, { root: true });
   },
+  destroyGeometry({ commit }, geometryId) {
+    commit('destroyGeometry', { id: geometryId });
+  },
 
   /*
   * Erase the selection defined by a set of points on all faces on the current story

--- a/src/store/modules/geometry/mutations.js
+++ b/src/store/modules/geometry/mutations.js
@@ -30,6 +30,7 @@ export function initGeometry(state, payload) {
       const { geometry } = payload;
       state.push(geometry);
 }
+
 export function createVertex(state, payload) {
       const { geometry_id, vertex } = payload;
       state.find(g => g.id === geometry_id).vertices.push(vertex);

--- a/src/store/modules/models/actions.js
+++ b/src/store/modules/models/actions.js
@@ -43,7 +43,7 @@ export default {
       const story = stories[storyIndex];
 
       context.commit('destroyStory', { story });
-
+      context.dispatch('geometry/destroyGeometry', story.geometry_id, { root: true });
       if (stories.length === 0) {
         context.dispatch('initStory');
       } else {

--- a/src/store/modules/models/factory.js
+++ b/src/store/modules/models/factory.js
@@ -37,6 +37,10 @@ const readPropertyAttrs = (attr) => {
 
 export const ip_defaults = readPropertyAttrs('default');
 if (ip_defaults.Project.config.units !== 'ip') {
+  // We're assuming the defaults in the schema are all in ip units.
+  // if that is not the case, we need to swap around which of
+  // `ip_defaults` and `si_defaults` is read directly from the schema and
+  // which is converted using getConverter
   throw new Error(
       'Expected default units to be ip. Code changes are required to change the default units');
 }

--- a/src/store/modules/models/factory.js
+++ b/src/store/modules/models/factory.js
@@ -5,6 +5,7 @@ import generateColor from './../../utilities/generateColor';
 import generateTexture from './../../utilities/generateTexture';
 import appconfig from './../application/appconfig';
 import schema from '../../../../schema/geometry_schema.json';
+import { getConverter } from '../../utilities/unitConversion';
 
 const makeReadPropertyAttr = (attribute) => {
   const readPropertyAttr = (definition) => {
@@ -34,7 +35,26 @@ const readPropertyAttrs = (attr) => {
   });
 };
 
-export const defaults = readPropertyAttrs('default');
+export const ip_defaults = readPropertyAttrs('default');
+if (ip_defaults.Project.config.units !== 'ip') {
+  throw new Error(
+      'Expected default units to be ip. Code changes are required to change the default units');
+}
+export const si_defaults = _.mapValues(
+  ip_defaults,
+  (value, key) => getConverter(key, 'ip_units', 'si_units')(value));
+
+export const defaults = new Proxy(
+  { ip_defaults, si_defaults },
+  {
+    get(target, key) {
+      return _.cloneDeep(_.get(window, 'application.$store.state.project.config.units', 'ip') === 'ip' ?
+        ip_defaults[key] :
+        si_defaults[key]);
+    },
+  },
+);
+
 export const allowableTypes = readPropertyAttrs('type');
 
 export default {

--- a/src/store/modules/project/actions.js
+++ b/src/store/modules/project/actions.js
@@ -3,9 +3,13 @@ import Validator from './../../utilities/validator';
 
 export default {
     // CONFIG
-  setUnits(context, payload) {
+  setUnits({ commit, dispatch, rootState }, payload) {
     if (payload.units === 'm' || payload.units === 'ft') {
-      context.commit('setUnits', payload);
+      throw new Error('units must be "ip" or "si"');
+    } else if (payload.units === 'ip' || payload.units === 'si') {
+      commit('setUnits', payload);
+      rootState.models.stories.forEach(
+        story => dispatch('models/destroyStory', { story }, { root: true }));
     }
   },
     setLanguage (context, payload) {

--- a/src/store/modules/project/index.js
+++ b/src/store/modules/project/index.js
@@ -7,7 +7,7 @@ export default {
   state: {
     // project
     config: {
-      units: 'ft',
+      units: 'ip',
       unitsEditable: true,
       language: 'EN-US',
     },

--- a/src/store/utilities/importFloorplan.js
+++ b/src/store/utilities/importFloorplan.js
@@ -10,6 +10,11 @@ function maybeUpdateProject(project) {
     project.north_axis = project.north_axis || project.config.north_axis;
     delete project.config.north_axis;
   }
+  project.config.units = (
+      project.config.units === 'ft' ? 'ip' :
+      project.config.units === 'm' ? 'si' :
+      project.config.units);
+
   return project;
 }
 


### PR DESCRIPTION
convert them to si units when that is the project config setting.

A caveat here is that we're destroying any stories that have already been created (because they are using the defaults for the wrong unit system).

Also, we now use `si` and `ip` in the schema Project.config.units field, rather than `ft` and `m`.

Addresses #293 