### PR TITLE
fix typo of config.snapMod to config.snapMode

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -38,7 +38,7 @@ window.api = {
     if (config === undefined) {
       config = {}; // eslint-disable-line
     }
-    if (config.snapMode && !_.includes(['grid-strict', 'grid-verts-edges'], config.snapMod)) {
+    if (config.snapMode && !_.includes(['grid-strict', 'grid-verts-edges'], config.snapMode)) {
       throw new Error('unrecognized value for snapMode: ' + config.snapMode + '. expected \'grid-strict\' or \'grid-verts-edges\'');
     }
     window.api.config = _.assign({


### PR DESCRIPTION
This PR is in response to issue #335 . 

