### PR TITLE
fix(createFaceFromPoints): fix calculating intersectedFaces

### DIFF
--- a/src/store/modules/geometry/actions/createFaceFromPoints.js
+++ b/src/store/modules/geometry/actions/createFaceFromPoints.js
@@ -78,6 +78,10 @@ export function newGeometriesOfOverlappedFaces(points, geometry) {
   const geom = geometryHelpers.denormalize(geometry);
   const intersectedFaces = geom.faces
     .filter((face) => {
+      // handle unusual cases where face has no vertices
+      if (face.vertices.length === 0) {
+        return false
+      }
       const inter = geometryHelpers.intersection(face.vertices, points);
       // We care about faces have an intersection with the new one, or that
       // cause errors (eg, split face) upon intersection


### PR DESCRIPTION
I found an issue in loading an exported floorplan (see file `Performance Degradation.json` in this thread #348 ).
It throws the following exception:
```
TypeError: coords[0] is undefinedapp.js line 726 > eval:61:7
    toTurfPoly http://localhost:8080/app.js line 726 > eval:61
    setOperation http://localhost:8080/app.js line 726 > eval:274
    intersection http://localhost:8080/app.js line 726 > eval:295
    intersectedFaces http://localhost:8080/app.js line 2784 > eval:122
    filter self-hosted:318
    newGeometriesOfOverlappedFaces http://localhost:8080/app.js line 2784 > eval:121
    createFaceFromPoints http://localhost:8080/app.js line 2784 > eval:94
    wrappedActionHandler http://localhost:8080/app.js line 768 > eval:706
    dispatch http://localhost:8080/app.js line 768 > eval:428
    boundDispatch http://localhost:8080/app.js line 768 > eval:334
    overrideDispatch http://localhost:8080/app.js line 2868 > eval:94
    saveRectangularFace http://localhost:8080/app.js line 2736 > eval:487
    boundFn http://localhost:8080/app.js line 606 > eval:191
    addPoint http://localhost:8080/app.js line 2736 > eval:235
    boundFn http://localhost:8080/app.js line 606 > eval:191
    gridClicked http://localhost:8080/app.js line 2736 > eval:64
    boundFn http://localhost:8080/app.js line 606 > eval:189
    contextListener http://localhost:8080/app.js line 1026 > eval:124
```
Steps to replicate:
- Run most recent version of floorspace.js (dev server or build for production)
- Load the Performance Degredation.json file
- Click "+" to create a new space, then click somewhere on map to create it



For some reason this model has some faces with no vertices, so we need to check if that's the case and skip it if so.