### PR TITLE
refactor(geometry): add edgesMap

### DIFF
--- a/src/store/modules/geometry/factory.js
+++ b/src/store/modules/geometry/factory.js
@@ -27,7 +27,8 @@ export default {
             id: idFactory.generate(),
             vertices: [],
             edges: [],
-            faces: []
+            faces: [],
+            edgesMap: {},
         }
     }
 }

--- a/src/store/modules/geometry/helpers.js
+++ b/src/store/modules/geometry/helpers.js
@@ -407,7 +407,7 @@ const helpers = {
 
     // given an edge id, find the edge on the geometry set with that id
     edgeForId(edge_id, geometry) {
-        return geometry.edges.find(e => e.id === edge_id);
+        return geometry.edgesMap[edge_id];
     },
 
     // given a vertex id returns edges referencing that vertex
@@ -529,6 +529,7 @@ const helpers = {
       ...geometry,
       edges,
       faces,
+      edgesMap: _.keyBy(edges, 'id'),
     };
   },
 
@@ -544,15 +545,17 @@ const helpers = {
         [
           ...geometry.vertices,
           ..._.flatMap(edges, e => [e.v1, e.v2]),
-        ], 'id');
-    return {
-      id: geometry.id,
-      vertices: vertices.map(v => _.pick(v, ['id', 'x', 'y'])),
-      edges: edges.map(e => ({
+        ], 'id'),
+      edgesPicked = edges.map(e => ({
         id: e.id,
         v1: e.v1.id,
         v2: e.v2.id,
-      })),
+      }));
+    return {
+      id: geometry.id,
+      vertices: vertices.map(v => _.pick(v, ['id', 'x', 'y'])),
+      edges: edgesPicked,
+      edgesMap: _.keyBy(edgesPicked, 'id'),
       faces: geometry.faces.map(f => ({
         id: f.id,
         edgeRefs: f.edges.map(er => ({ edge_id: er.id, reverse: er.reverse })),

--- a/src/store/modules/geometry/index.js
+++ b/src/store/modules/geometry/index.js
@@ -23,7 +23,14 @@ export default {
                 edge_id: null,
                 reverse: false
             }]
-        }]
+        }],
+        edgesMap: {
+            <edge_id>: {
+                id: null,
+                v1: null,
+                v2: null,
+            }
+        }
     }*/],
     actions: actions,
     mutations: mutations,

--- a/test/unit/specs/geometry/examples.js
+++ b/test/unit/specs/geometry/examples.js
@@ -1,5 +1,5 @@
 export const emptyGeometry = {
-  id: 2, vertices: [], edges: [], faces: []
+  id: 2, vertices: [], edges: [], faces: [], edgesMap: {},
 };
 
 /*
@@ -14,6 +14,9 @@ export const emptyGeometry = {
     f +---------+ g
 
 */
+const simpleGeometryEdges = [
+  'ab', 'ac', 'bd', 'cd', 'eg', 'gf', 'fc', 'ce',
+].map(id => ({ id, v1: id[0], v2: id[1] }));
 export const simpleGeometry = {
   /* eslint-disable */
   id: 1,
@@ -26,9 +29,8 @@ export const simpleGeometry = {
     {id: 'a', x: 0, y: 16},
     {id: 'b', x: 4, y: 16},
   ],
-  edges: [
-    'ab', 'ac', 'bd', 'cd', 'eg', 'gf', 'fc', 'ce',
-  ].map(id => ({ id, v1: id[0], v2: id[1] })),
+  edges: simpleGeometryEdges,
+  edgesMap: simpleGeometryEdges.reduce((acc, cur) => ({...acc, [cur.id]: cur}), {}),
   faces: [
     {id: 'top', edgeRefs: [
       {edge_id: 'ab', reverse: false},
@@ -46,6 +48,9 @@ export const simpleGeometry = {
   /* eslint-enable */
 };
 
+const smallGeometryEdges = [
+  'ab', 'ac', 'bd', 'cd', 'eg', 'gf', 'fc', 'ce',
+].map(id => ({ id, v1: id[0], v2: id[1] }));
 export const smallGeometry = {
   /* eslint-disable */
   id: 1,
@@ -58,9 +63,8 @@ export const smallGeometry = {
     { id: 'a', x: 0, y: 1.6 },
     { id: 'b', x: .4, y: 1.6 },
   ],
-  edges: [
-    'ab', 'ac', 'bd', 'cd', 'eg', 'gf', 'fc', 'ce',
-  ].map(id => ({ id, v1: id[0], v2: id[1] })),
+  edges: smallGeometryEdges,
+  edgesMap: smallGeometryEdges.reduce((acc, cur) => ({...acc, [cur.id]: cur}), {}),
   faces: [
     {
       id: 'top', edgeRefs: [
@@ -82,6 +86,9 @@ export const smallGeometry = {
   /* eslint-enable */
 };
 
+const evenSmallerEdges = [
+  'ab', 'ac', 'bd', 'cd', 'eg', 'gf', 'fc', 'ce',
+].map(id => ({ id, v1: id[0], v2: id[1] }));
 export const evenSmallerGeometry = {
   /* eslint-disable */
   id: 1,
@@ -94,9 +101,8 @@ export const evenSmallerGeometry = {
     { id: 'a', x: 0, y: 0.16 },
     { id: 'b', x: 0.04, y: 0.16 },
   ],
-  edges: [
-    'ab', 'ac', 'bd', 'cd', 'eg', 'gf', 'fc', 'ce',
-  ].map(id => ({ id, v1: id[0], v2: id[1] })),
+  edges: evenSmallerEdges,
+  edgesMap: evenSmallerEdges.reduce((acc, cur) => ({...acc, [cur.id]: cur}), {}),
   faces: [
     {
       id: 'top', edgeRefs: [
@@ -119,6 +125,14 @@ export const evenSmallerGeometry = {
 };
 
 // https://trello-attachments.s3.amazonaws.com/58d428743111af1d0a20cf28/598b63629862dc7224f4df8c/1bc285908438ddc20e64c55752191727/capture.png
+const preserveRectangularityEdges = [
+  {"id":"8","v1":"4","v2":"5"},{"id":"9","v1":"5","v2":"6"},
+  {"id":"10","v1":"6","v2":"7"},{"id":"11","v1":"7","v2":"4"},
+  {"id":"16","v1":"6","v2":"14"},{"id":"17","v1":"14","v2":"15"},
+  {"id":"18","v1":"15","v2":"5"},{"id":"79","v1":"39","v2":"78"},
+  {"id":"80","v1":"78","v2":"7"},{"id":"41","v1":"15","v2":"38"},
+  {"id":"42","v1":"38","v2":"39"},{"id":"83","v1":"7","v2":"6"},
+  {"id":"84","v1":"6","v2":"14"}];
 export const preserveRectangularityGeometry = {
   /* eslint-disable */
   "id":"2","vertices":[
@@ -126,14 +140,8 @@ export const preserveRectangularityGeometry = {
     {"id":"6","x":3,"y":0},{"id":"7","x":0,"y":0},{"id":"14","x":7,"y":0},
     {"id":"15","x":7,"y":-4},{"id":"39","x":8,"y":1},{"id":"78","x":0,"y":1},
     {"id":"38","x":8,"y":-4}
-  ],"edges":[
-    {"id":"8","v1":"4","v2":"5"},{"id":"9","v1":"5","v2":"6"},
-    {"id":"10","v1":"6","v2":"7"},{"id":"11","v1":"7","v2":"4"},
-    {"id":"16","v1":"6","v2":"14"},{"id":"17","v1":"14","v2":"15"},
-    {"id":"18","v1":"15","v2":"5"},{"id":"79","v1":"39","v2":"78"},
-    {"id":"80","v1":"78","v2":"7"},{"id":"41","v1":"15","v2":"38"},
-    {"id":"42","v1":"38","v2":"39"},{"id":"83","v1":"7","v2":"6"},
-    {"id":"84","v1":"6","v2":"14"}],
+  ],"edges": preserveRectangularityEdges,
+  "edgesMap": preserveRectangularityEdges.reduce((acc, cur) => ({...acc, [cur.id]: cur}), {}),
   "faces":[
     {"id":"12","edgeRefs":[{"edge_id":"8","reverse":false},{"edge_id":"9","reverse":false},{"edge_id":"10","reverse":false},{"edge_id":"11","reverse":false}]},
     {"id":"19","edgeRefs":[{"edge_id":"16","reverse":false},{"edge_id":"17","reverse":false},{"edge_id":"18","reverse":false},{"edge_id":"9","reverse":false}]},
@@ -142,19 +150,89 @@ export const preserveRectangularityGeometry = {
   /* eslint-enable */
 };
 
+const neg5by5Edges = [
+  { id: 'top', v1: 'origin', v2: '(-5, 0)' },
+  { id: 'left', v1: '(-5, 0)', v2: '(-5, -5)' },
+  { id: 'bottom', v1: '(-5, -5)', v2: '(0, -5)' },
+  { id: 'right', v1: '(0, -5)', v2: 'origin' }
+];
 export const neg5by5Rect = {
   id: 3,
   vertices: [
     { x: 0, y: 0, id: 'origin' }, { x: -5, y: 0, id: '(-5, 0)' },
     { x: -5, y: -5, id: '(-5, -5)' }, { x: 0, y: -5, id: '(0, -5)' }],
-  edges: [
-    { id: 'top', v1: 'origin', v2: '(-5, 0)' },
-    { id: 'left', v1: '(-5, 0)', v2: '(-5, -5)' },
-    { id: 'bottom', v1: '(-5, -5)', v2: '(0, -5)' },
-    { id: 'right', v1: '(0, -5)', v2: 'origin' }],
+  edges: neg5by5Edges,
+  edgesMap: neg5by5Edges.reduce((acc, cur) => ({...acc, [cur.id]: cur}), {}),
   faces: [],
 };
 
+const emptyEdgesEdges = [
+  {
+    id: '9',
+    v1: '5',
+    v2: '6',
+  },
+  {
+    id: '10',
+    v1: '6',
+    v2: '7',
+  },
+  {
+    id: '11',
+    v1: '7',
+    v2: '8',
+  },
+  {
+    id: '12',
+    v1: '8',
+    v2: '5',
+  },
+  {
+    id: '79',
+    v1: '6',
+    v2: '75',
+  },
+  {
+    id: '80',
+    v1: '75',
+    v2: '76',
+  },
+  {
+    id: '81',
+    v1: '76',
+    v2: '77',
+  },
+  {
+    id: '82',
+    v1: '77',
+    v2: '78',
+  },
+  {
+    id: '83',
+    v1: '78',
+    v2: '5',
+  },
+  {
+    id: '71',
+    v1: '67',
+    v2: '68',
+  },
+  {
+    id: '72',
+    v1: '68',
+    v2: '69',
+  },
+  {
+    id: '73',
+    v1: '69',
+    v2: '70',
+  },
+  {
+    id: '74',
+    v1: '70',
+    v2: '67',
+  },
+];
 export const emptyEdgesProblem = {
   id: '2',
   vertices: [
@@ -219,73 +297,8 @@ export const emptyEdgesProblem = {
       y: 74.8,
     },
   ],
-  edges: [
-    {
-      id: '9',
-      v1: '5',
-      v2: '6',
-    },
-    {
-      id: '10',
-      v1: '6',
-      v2: '7',
-    },
-    {
-      id: '11',
-      v1: '7',
-      v2: '8',
-    },
-    {
-      id: '12',
-      v1: '8',
-      v2: '5',
-    },
-    {
-      id: '79',
-      v1: '6',
-      v2: '75',
-    },
-    {
-      id: '80',
-      v1: '75',
-      v2: '76',
-    },
-    {
-      id: '81',
-      v1: '76',
-      v2: '77',
-    },
-    {
-      id: '82',
-      v1: '77',
-      v2: '78',
-    },
-    {
-      id: '83',
-      v1: '78',
-      v2: '5',
-    },
-    {
-      id: '71',
-      v1: '67',
-      v2: '68',
-    },
-    {
-      id: '72',
-      v1: '68',
-      v2: '69',
-    },
-    {
-      id: '73',
-      v1: '69',
-      v2: '70',
-    },
-    {
-      id: '74',
-      v1: '70',
-      v2: '67',
-    },
-  ],
+  edges: emptyEdgesEdges,
+  edgesMap: emptyEdgesEdges.reduce((acc, cur) => ({...acc, [cur.id]: cur}), {}),
   faces: [
     {
       id: '13',


### PR DESCRIPTION
Partially addresses some performance issues by adding a hashmap of edges to the geometry objects. This allows the helper function `edgeById` to run in ~O(1) time - which is called many times when deleting spaces.

This is not the ideal solution as it replicates state in the store (in geometry.edges and geometry.edgesMap), but is a good first step with improved performance. The following step would be to consider refactoring geometry.edges array into an array of id's

## Changes/Additions
- tests: refactor examples and some tests to use new geometry structure
- geometry/mutations: add/update/delete entries in edgesMap whenever edges are changed
- geometry/helpers: make sure functions are using the new structure when returning geometry objects
