### PR TITLE
Resolution for the Internal ID bug

### DIFF
--- a/src/store/utilities/importFloorplan.js
+++ b/src/store/utilities/importFloorplan.js
@@ -113,7 +113,7 @@ export default function importFloorplan(context, payload) {
   let largestId = 0;
   forEachNestedProp(payload, (k, v) => {
     if (k && k === 'id' && (+v > largestId)) {
-      largestId = v;
+      largestId = +v;
     }
   });
 


### PR DESCRIPTION
Make "largestID" sum with "v" (int) rather than concatenate (str)
Tested by creating a simple geometry with one space, saving, then adding a second space and saving again. Opening the first file and re-adding the second space, and saving for a third time. Before the change, this process produced different internal IDs in the second and third save files. After this change the IDs were identical, as intended