### PR TITLE
Fix bug for spaces without edges

### DIFF
--- a/src/store/modules/geometry/mutations.js
+++ b/src/store/modules/geometry/mutations.js
@@ -26,6 +26,7 @@ export function trimGeometry(state, { geometry_id, vertsReferencedElsewhere }) {
   }
   geometry.vertices = newVerts;
   geometry.edges = newEdges;
+  geometry.faces = geometry.faces.filter(face => face.edgeRefs.length > 0);
 }
 
 export function initGeometry(state, payload) {

--- a/test/unit/specs/geometry/mutations.spec.js
+++ b/test/unit/specs/geometry/mutations.spec.js
@@ -92,4 +92,20 @@ describe('trimGeometry', () => {
     trimGeometry([geometry], { geometry_id: geometry.id, vertsReferencedElsewhere: ['used by daylighting control'] });
     assert(_.find(geometry.vertices, { id: 'used by daylighting control' }));
   });
+
+  it('removes faces that have no edges', () => {
+    const geometry = _.cloneDeep(simpleGeometry);
+    const length = geometry.faces.length;
+    // Verify that we start with two points
+    assertEqual(length, 2);
+    geometry.faces[length - 1].edgeRefs = [];
+
+    // Verify that only faces without edges are removed
+    trimGeometry([geometry], { geometry_id: geometry.id });
+    assertEqual(geometry.faces.length, length - 1);
+
+    geometry.faces[0].edgeRefs = [];
+    trimGeometry([geometry], { geometry_id: geometry.id });
+    assertEqual(geometry.faces.length, length - 2);
+  });
 });


### PR DESCRIPTION
Resolves https://github.com/NREL/floorspace.js/issues/398

This issue turned out to be simpler than anticipated - whenever `trimGeometry` is called, it looks for any faces that have no edges and removes them from the list of faces.  Removing those faces prevents the bug from occurring, but allows the space to continue existing.